### PR TITLE
minimal changes to get camera intent working for Android 10 users

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,11 +4,12 @@
 
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"/>
+        android:maxSdkVersion="29"/>
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false"/>
     <application
+        android:requestLegacyExternalStorage="true"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/app/src/main/java/om/sstvencoder/MainActivity.java
+++ b/app/src/main/java/om/sstvencoder/MainActivity.java
@@ -191,7 +191,7 @@ public class MainActivity extends AppCompatActivity {
 
     private boolean needsRequestWritePermission() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                Build.VERSION.SDK_INT > Build.VERSION_CODES.Q)
             return false;
         String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
         int state = ContextCompat.checkSelfPermission(this, permission);


### PR DESCRIPTION
This is only a temporary workaround for Android 10 users:
- Enable permission request to write to external storage for Android 10
- Enable old behaviour prior Android 10 for external storage

See also this blog entry:
https://commonsware.com/blog/2019/06/07/death-external-storage-end-saga.html

Without this change, touching the camera button consistently crashes the camera on Android 10.
Here the captured log:
```
2020-06-29 11:39:19.737 9053-9053/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.android.camera2, PID: 9053
    java.lang.RuntimeException: Unable to start activity ComponentInfo{com.android.camera2/com.android.camera.CaptureActivity}: java.lang.NullPointerException: Attempt to get length of null array
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3270)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
        at android.os.Handler.dispatchMessage(Handler.java:107)
        at android.os.Looper.loop(Looper.java:214)
        at android.app.ActivityThread.main(ActivityThread.java:7356)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
     Caused by: java.lang.NullPointerException: Attempt to get length of null array
        at com.android.camera.CameraActivity.shouldUseNoOpLocation(CameraActivity.java:1753)
        at com.android.camera.CameraActivity.onCreateTasks(CameraActivity.java:1438)
        at com.android.camera.util.QuickActivity.onCreate(QuickActivity.java:114)
        at android.app.Activity.performCreate(Activity.java:7802)
        at android.app.Activity.performCreate(Activity.java:7791)
        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1299)
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3245)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3409) 
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:83) 
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016) 
        at android.os.Handler.dispatchMessage(Handler.java:107) 
        at android.os.Looper.loop(Looper.java:214) 
        at android.app.ActivityThread.main(ActivityThread.java:7356) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```