### PR TITLE
Temporarily opt out of Edge-to-Edge enforcement

### DIFF
--- a/app/src/main/res/values-v35/styles.xml
+++ b/app/src/main/res/values-v35/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<style name="AppTheme" parent="Base.Theme.AppCompat">
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+	</style>
+</resources>


### PR DESCRIPTION
Edge-to-Edge is enforced since Android 15 and should be handled with insets:

![screenshot1](https://github.com/user-attachments/assets/d7ea68c1-6fa1-41cc-b301-38fb00188145)

![screenshot2](https://github.com/user-attachments/assets/6669b66a-7c07-4c1f-8b53-9f280a7a0da7)

Luckily there is a way to temporarily opt out of this enforcement and restore the previous behavior.